### PR TITLE
Update parser restrictions

### DIFF
--- a/dbt_artifacts_parser/parsers/catalog/catalog_v1.py
+++ b/dbt_artifacts_parser/parsers/catalog/catalog_v1.py
@@ -12,7 +12,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class CatalogMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/catalog/v1.json'
     dbt_version: Optional[str] = '0.19.0'
@@ -23,7 +23,7 @@ class CatalogMetadata(BaseParserModel):
 
 class TableMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: str
     database: Optional[str] = None
@@ -35,7 +35,7 @@ class TableMetadata(BaseParserModel):
 
 class ColumnMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: str
     comment: Optional[str] = None
@@ -45,7 +45,7 @@ class ColumnMetadata(BaseParserModel):
 
 class StatsItem(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     label: str
@@ -56,7 +56,7 @@ class StatsItem(BaseParserModel):
 
 class CatalogTable(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: TableMetadata
     columns: Dict[str, ColumnMetadata]
@@ -66,7 +66,7 @@ class CatalogTable(BaseParserModel):
 
 class CatalogV1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: CatalogMetadata
     nodes: Dict[str, CatalogTable]

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v1.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v1.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -136,7 +136,7 @@ class ResourceType5(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     namespace: Optional[str] = None
     name: str
@@ -181,7 +181,7 @@ class ResourceType9(Enum):
 
 class ParsedDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -252,7 +252,7 @@ class ResourceType13(Enum):
 
 class ParsedSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -313,7 +313,7 @@ class ResourceType14(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -463,7 +463,7 @@ class ResourceType16(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -473,7 +473,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v1.json'
     dbt_version: Optional[str] = '0.19.0'
@@ -488,7 +488,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -510,7 +510,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     period: Period
@@ -539,14 +539,14 @@ class ResourceType17(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -555,7 +555,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -596,7 +596,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     email: str
     name: Optional[str] = None
@@ -623,7 +623,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -683,7 +683,7 @@ class CompiledDataTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -742,7 +742,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -802,7 +802,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -861,7 +861,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -923,7 +923,7 @@ class CompiledSchemaTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -983,7 +983,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1042,7 +1042,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1096,7 +1096,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1151,7 +1151,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1205,7 +1205,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1259,7 +1259,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1295,7 +1295,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -1304,7 +1304,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1328,7 +1328,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -1353,7 +1353,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     unique_id: str
@@ -1377,7 +1377,7 @@ class ParsedExposure(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1436,7 +1436,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1475,7 +1475,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v10.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v10.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[
         str
@@ -44,7 +44,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -58,7 +58,7 @@ class OnConfigurationChange(Enum):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -67,7 +67,7 @@ class Hook(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -75,7 +75,7 @@ class Docs(BaseParserModel):
 
 class ContractConfig(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
 
@@ -91,7 +91,7 @@ class Type(Enum):
 
 class ColumnLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -102,7 +102,7 @@ class ColumnLevelConstraint(BaseParserModel):
 
 class RefArgs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     package: Optional[str] = None
@@ -111,7 +111,7 @@ class RefArgs(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -119,7 +119,7 @@ class DependsOn(BaseParserModel):
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -127,7 +127,7 @@ class InjectedCTE(BaseParserModel):
 
 class Contract(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     checksum: Optional[str] = None
@@ -176,7 +176,7 @@ class Access(Enum):
 
 class ModelLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -188,7 +188,7 @@ class ModelLevelConstraint(BaseParserModel):
 
 class DeferRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -210,7 +210,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -297,7 +297,7 @@ class SeedConfig(BaseParserModel):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
 
@@ -308,7 +308,7 @@ class ResourceType9(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -324,7 +324,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -358,7 +358,7 @@ class SupportedLanguage(Enum):
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -371,7 +371,7 @@ class ResourceType11(Enum):
 
 class Documentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType11
@@ -436,7 +436,7 @@ class GrainToDate(Enum):
 
 class WhereFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_sql_template: str
 
@@ -459,7 +459,7 @@ class Granularity(Enum):
 
 class MetricTimeWindow(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -467,7 +467,7 @@ class MetricTimeWindow(BaseParserModel):
 
 class FileSlice(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     filename: str
     content: str
@@ -489,7 +489,7 @@ class ResourceType14(Enum):
 
 class Group(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType14
@@ -520,7 +520,7 @@ class ResourceType15(Enum):
 
 class NodeRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     alias: str
     schema_name: str
@@ -530,7 +530,7 @@ class NodeRelation(BaseParserModel):
 
 class Defaults(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     agg_time_dimension: Optional[str] = None
 
@@ -544,7 +544,7 @@ class Type4(Enum):
 
 class Entity(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Type4
@@ -567,7 +567,7 @@ class Agg(Enum):
 
 class MeasureAggregationParameters(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     percentile: Optional[float] = None
     use_discrete_percentile: Optional[bool] = False
@@ -588,7 +588,7 @@ class WindowChoice(Enum):
 
 class NonAdditiveDimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     window_choice: WindowChoice
@@ -610,7 +610,7 @@ class TimeGranularity(Enum):
 
 class DimensionValidityParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     is_start: Optional[bool] = False
     is_end: Optional[bool] = False
@@ -670,7 +670,7 @@ class ColumnInfo(BaseParserModel):
 
 class SingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -741,7 +741,7 @@ class SingularTestNode(BaseParserModel):
 
 class HookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -820,7 +820,7 @@ class HookNode(BaseParserModel):
 
 class ModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -904,7 +904,7 @@ class ModelNode(BaseParserModel):
 
 class RPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -982,7 +982,7 @@ class RPCNode(BaseParserModel):
 
 class SqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1060,7 +1060,7 @@ class SqlNode(BaseParserModel):
 
 class GenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     test_metadata: TestMetadata
     database: Optional[str] = None
@@ -1135,7 +1135,7 @@ class GenericTestNode(BaseParserModel):
 
 class SnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1187,7 +1187,7 @@ class SnapshotNode(BaseParserModel):
 
 class SeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1254,7 +1254,7 @@ class SeedNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1274,7 +1274,7 @@ class ExternalTable(BaseParserModel):
 
 class Macro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType10
@@ -1299,7 +1299,7 @@ class Macro(BaseParserModel):
 
 class Exposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType12
@@ -1331,7 +1331,7 @@ class Exposure(BaseParserModel):
 
 class MetricInputMeasure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[WhereFilter] = None
@@ -1340,7 +1340,7 @@ class MetricInputMeasure(BaseParserModel):
 
 class MetricInput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[WhereFilter] = None
@@ -1351,7 +1351,7 @@ class MetricInput(BaseParserModel):
 
 class SourceFileMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     repo_file_path: str
     file_slice: FileSlice
@@ -1359,7 +1359,7 @@ class SourceFileMetadata(BaseParserModel):
 
 class Measure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     agg: Agg
@@ -1373,7 +1373,7 @@ class Measure(BaseParserModel):
 
 class DimensionTypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     time_granularity: TimeGranularity
     validity_params: Optional[DimensionValidityParams] = None
@@ -1381,7 +1381,7 @@ class DimensionTypeParams(BaseParserModel):
 
 class AnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1459,7 +1459,7 @@ class AnalysisNode(BaseParserModel):
 
 class SourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1498,7 +1498,7 @@ class SourceDefinition(BaseParserModel):
 
 class MetricTypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     measure: Optional[MetricInputMeasure] = None
     input_measures: Optional[List[MetricInputMeasure]] = []
@@ -1512,7 +1512,7 @@ class MetricTypeParams(BaseParserModel):
 
 class Dimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Type5
@@ -1525,7 +1525,7 @@ class Dimension(BaseParserModel):
 
 class Metric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType13
@@ -1560,7 +1560,7 @@ class Metric(BaseParserModel):
 
 class SemanticModel(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType15
@@ -1590,7 +1590,7 @@ class SemanticModel(BaseParserModel):
 
 class ManifestV10(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v11.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v11.py
@@ -14,7 +14,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = None
     dbt_version: Optional[str] = '1.8.0a1'
@@ -39,7 +39,7 @@ class ManifestMetadata(BaseParserModel):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -47,7 +47,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -56,7 +56,7 @@ class Hook(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -64,7 +64,7 @@ class Docs(BaseParserModel):
 
 class ContractConfig(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -116,7 +116,7 @@ class Type(Enum):
 
 class ColumnLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -141,7 +141,7 @@ class ColumnInfo(BaseParserModel):
 
 class RefArgs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     package: Optional[str] = None
@@ -150,7 +150,7 @@ class RefArgs(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = None
     nodes: Optional[List[str]] = None
@@ -158,7 +158,7 @@ class DependsOn(BaseParserModel):
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -166,7 +166,7 @@ class InjectedCTE(BaseParserModel):
 
 class Contract(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -175,7 +175,7 @@ class Contract(BaseParserModel):
 
 class AnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -245,7 +245,7 @@ class TestConfig(BaseParserModel):
 
 class SingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -290,7 +290,7 @@ class SingularTestNode(BaseParserModel):
 
 class HookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -372,7 +372,7 @@ class ModelConfig(BaseParserModel):
 
 class ModelLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -384,7 +384,7 @@ class ModelLevelConstraint(BaseParserModel):
 
 class DeferRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -394,7 +394,7 @@ class DeferRelation(BaseParserModel):
 
 class ModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -445,7 +445,7 @@ class ModelNode(BaseParserModel):
 
 class RPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -490,7 +490,7 @@ class RPCNode(BaseParserModel):
 
 class SqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -535,7 +535,7 @@ class SqlNode(BaseParserModel):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = None
@@ -544,7 +544,7 @@ class TestMetadata(BaseParserModel):
 
 class GenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     test_metadata: TestMetadata
     database: Optional[str] = None
@@ -627,7 +627,7 @@ class SnapshotConfig(BaseParserModel):
 
 class SnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -704,14 +704,14 @@ class SeedConfig(BaseParserModel):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = None
 
 
 class SeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -747,7 +747,7 @@ class SeedNode(BaseParserModel):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -763,7 +763,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -771,7 +771,7 @@ class Time(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -811,7 +811,7 @@ class SourceConfig(BaseParserModel):
 
 class SourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -845,7 +845,7 @@ class SourceDefinition(BaseParserModel):
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -859,7 +859,7 @@ class SupportedLanguage(Enum):
 
 class Macro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['macro']
@@ -880,7 +880,7 @@ class Macro(BaseParserModel):
 
 class Documentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['doc']
@@ -924,7 +924,7 @@ class Maturity(Enum):
 
 class Exposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['exposure']
@@ -952,21 +952,21 @@ class Exposure(BaseParserModel):
 
 class WhereFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_sql_template: str
 
 
 class WhereFilterIntersection(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class MetricInputMeasure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[WhereFilterIntersection] = None
@@ -985,7 +985,7 @@ class Granularity(Enum):
 
 class MetricTimeWindow(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -1001,7 +1001,7 @@ class OffsetToGrain(Enum):
 
 class MetricInput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[WhereFilterIntersection] = None
@@ -1020,7 +1020,7 @@ class GrainToDate(Enum):
 
 class MetricTypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     measure: Optional[MetricInputMeasure] = None
     input_measures: Optional[List[MetricInputMeasure]] = None
@@ -1034,7 +1034,7 @@ class MetricTypeParams(BaseParserModel):
 
 class FileSlice(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     filename: str
     content: str
@@ -1044,7 +1044,7 @@ class FileSlice(BaseParserModel):
 
 class SourceFileMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     repo_file_path: str
     file_slice: FileSlice
@@ -1068,7 +1068,7 @@ class Type3(Enum):
 
 class Metric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['metric']
@@ -1097,7 +1097,7 @@ class Metric(BaseParserModel):
 
 class Group(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['group']
@@ -1110,7 +1110,7 @@ class Group(BaseParserModel):
 
 class QueryParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metrics: List[str]
     group_by: List[str]
@@ -1124,7 +1124,7 @@ class ExportAs(Enum):
 
 class ExportConfig(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     export_as: ExportAs
     schema_name: Optional[str] = None
@@ -1133,7 +1133,7 @@ class ExportConfig(BaseParserModel):
 
 class Export(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     config: ExportConfig
@@ -1170,7 +1170,7 @@ class ResourceType(Enum):
 
 class SavedQuery(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType
@@ -1194,7 +1194,7 @@ class SavedQuery(BaseParserModel):
 
 class NodeRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     alias: str
     schema_name: str
@@ -1204,7 +1204,7 @@ class NodeRelation(BaseParserModel):
 
 class Defaults(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     agg_time_dimension: Optional[str] = None
 
@@ -1218,7 +1218,7 @@ class Type4(Enum):
 
 class Entity(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Type4
@@ -1230,7 +1230,7 @@ class Entity(BaseParserModel):
 
 class MeasureAggregationParameters(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     percentile: Optional[float] = None
     use_discrete_percentile: Optional[bool] = False
@@ -1251,7 +1251,7 @@ class WindowChoice(Enum):
 
 class NonAdditiveDimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     window_choice: WindowChoice
@@ -1272,7 +1272,7 @@ class Agg(Enum):
 
 class Measure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     agg: Agg
@@ -1287,7 +1287,7 @@ class Measure(BaseParserModel):
 
 class DimensionValidityParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     is_start: Optional[bool] = False
     is_end: Optional[bool] = False
@@ -1303,7 +1303,7 @@ class TimeGranularity(Enum):
 
 class DimensionTypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     time_granularity: TimeGranularity
     validity_params: Optional[DimensionValidityParams] = None
@@ -1316,7 +1316,7 @@ class Type5(Enum):
 
 class Dimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Type5
@@ -1340,7 +1340,7 @@ class SemanticModelConfig(BaseParserModel):
 
 class SemanticModel(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType
@@ -1369,7 +1369,7 @@ class SemanticModel(BaseParserModel):
 
 class ManifestV11(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v11.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v11.py
@@ -152,7 +152,7 @@ class DependsOn(BaseParserModel):
     model_config = ConfigDict(
         extra='ignore',
     )
-    macros: Optional[List[str]] = None
+    macros: Optional[List[Optional[str]]] = None
     nodes: Optional[List[str]] = None
 
 
@@ -706,7 +706,7 @@ class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
         extra='ignore',
     )
-    macros: Optional[List[str]] = None
+    macros: Optional[List[Optional[str]]] = None
 
 
 class SeedNode(BaseParserModel):

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
@@ -161,7 +161,7 @@ class DependsOn(BaseParserModel):
     model_config = ConfigDict(
         extra='ignore',
     )
-    macros: Optional[List[str]] = None
+    macros: Optional[List[Optional[str]]] = None
     nodes: Optional[List[str]] = None
 
 
@@ -1249,7 +1249,7 @@ class DependsOn9(BaseParserModel):
     model_config = ConfigDict(
         extra='ignore',
     )
-    macros: Optional[List[str]] = None
+    macros: Optional[List[Optional[str]]] = None
 
 
 class Nodes9(BaseParserModel):
@@ -1494,7 +1494,7 @@ class DependsOn11(BaseParserModel):
     model_config = ConfigDict(
         extra='ignore',
     )
-    macros: Optional[List[str]] = None
+    macros: Optional[List[Optional[str]]] = None
     nodes: Optional[List[str]] = None
 
 
@@ -2960,7 +2960,7 @@ class DependsOn22(BaseParserModel):
     model_config = ConfigDict(
         extra='ignore',
     )
-    macros: Optional[List[str]] = None
+    macros: Optional[List[Optional[str]]] = None
 
 
 class Disabled9(BaseParserModel):
@@ -3115,7 +3115,7 @@ class DependsOn23(BaseParserModel):
     model_config = ConfigDict(
         extra='ignore',
     )
-    macros: Optional[List[str]] = None
+    macros: Optional[List[Optional[str]]] = None
     nodes: Optional[List[str]] = None
 
 

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
@@ -14,7 +14,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class Metadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = None
     dbt_version: Optional[str] = '1.8.0a1'
@@ -39,7 +39,7 @@ class Metadata(BaseParserModel):
 
 class Checksum(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -47,7 +47,7 @@ class Checksum(BaseParserModel):
 
 class PostHookItem(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -56,7 +56,7 @@ class PostHookItem(BaseParserModel):
 
 class PreHookItem(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -71,7 +71,7 @@ class OnConfigurationChange(Enum):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -79,7 +79,7 @@ class Docs(BaseParserModel):
 
 class Contract(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -125,7 +125,7 @@ class Type(Enum):
 
 class Constraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -150,7 +150,7 @@ class Columns(BaseParserModel):
 
 class Ref(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     package: Optional[str] = None
@@ -159,7 +159,7 @@ class Ref(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = None
     nodes: Optional[List[str]] = None
@@ -167,7 +167,7 @@ class DependsOn(BaseParserModel):
 
 class ExtraCte(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -175,7 +175,7 @@ class ExtraCte(BaseParserModel):
 
 class Contract1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -184,7 +184,7 @@ class Contract1(BaseParserModel):
 
 class Nodes(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -254,7 +254,7 @@ class Config1(BaseParserModel):
 
 class Constraint1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -279,7 +279,7 @@ class Columns1(BaseParserModel):
 
 class Nodes1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -324,7 +324,7 @@ class Nodes1(BaseParserModel):
 
 class Contract3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -361,7 +361,7 @@ class Config2(BaseParserModel):
 
 class Constraint2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -386,7 +386,7 @@ class Columns2(BaseParserModel):
 
 class Contract4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -395,7 +395,7 @@ class Contract4(BaseParserModel):
 
 class Nodes2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -441,7 +441,7 @@ class Nodes2(BaseParserModel):
 
 class Contract5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -485,7 +485,7 @@ class Config3(BaseParserModel):
 
 class Constraint3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -510,7 +510,7 @@ class Columns3(BaseParserModel):
 
 class Contract6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -519,7 +519,7 @@ class Contract6(BaseParserModel):
 
 class Constraint4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -531,7 +531,7 @@ class Constraint4(BaseParserModel):
 
 class DeferRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -541,7 +541,7 @@ class DeferRelation(BaseParserModel):
 
 class Nodes3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -592,7 +592,7 @@ class Nodes3(BaseParserModel):
 
 class Contract7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -629,7 +629,7 @@ class Config4(BaseParserModel):
 
 class Constraint5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -654,7 +654,7 @@ class Columns4(BaseParserModel):
 
 class Contract8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -663,7 +663,7 @@ class Contract8(BaseParserModel):
 
 class Nodes4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -708,7 +708,7 @@ class Nodes4(BaseParserModel):
 
 class Contract9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -745,7 +745,7 @@ class Config5(BaseParserModel):
 
 class Constraint6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -770,7 +770,7 @@ class Columns5(BaseParserModel):
 
 class Contract10(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -779,7 +779,7 @@ class Contract10(BaseParserModel):
 
 class Nodes5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -824,7 +824,7 @@ class Nodes5(BaseParserModel):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = None
@@ -858,7 +858,7 @@ class Config6(BaseParserModel):
 
 class Constraint7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -883,7 +883,7 @@ class Columns6(BaseParserModel):
 
 class Nodes6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     test_metadata: TestMetadata = Field(..., title='TestMetadata')
     database: Optional[str] = None
@@ -932,7 +932,7 @@ class Nodes6(BaseParserModel):
 
 class Contract12(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -974,7 +974,7 @@ class Config7(BaseParserModel):
 
 class Constraint8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -999,7 +999,7 @@ class Columns7(BaseParserModel):
 
 class Contract13(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -1008,7 +1008,7 @@ class Contract13(BaseParserModel):
 
 class Nodes7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1054,7 +1054,7 @@ class Nodes7(BaseParserModel):
 
 class Contract14(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -1092,7 +1092,7 @@ class Config8(BaseParserModel):
 
 class Constraint9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -1117,7 +1117,7 @@ class Columns8(BaseParserModel):
 
 class Contract15(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -1126,7 +1126,7 @@ class Contract15(BaseParserModel):
 
 class Overrides(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[Dict[str, Any]] = None
     vars: Optional[Dict[str, Any]] = None
@@ -1135,7 +1135,7 @@ class Overrides(BaseParserModel):
 
 class Nodes8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1183,7 +1183,7 @@ class Nodes8(BaseParserModel):
 
 class Contract16(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -1222,7 +1222,7 @@ class Config9(BaseParserModel):
 
 class Constraint10(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -1247,14 +1247,14 @@ class Columns9(BaseParserModel):
 
 class DependsOn9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = None
 
 
 class Nodes9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1290,7 +1290,7 @@ class Nodes9(BaseParserModel):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -1306,7 +1306,7 @@ class Period(Enum):
 
 class WarnAfter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -1314,7 +1314,7 @@ class WarnAfter(BaseParserModel):
 
 class ErrorAfter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -1322,7 +1322,7 @@ class ErrorAfter(BaseParserModel):
 
 class Freshness(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[WarnAfter] = None
     error_after: Optional[ErrorAfter] = None
@@ -1354,7 +1354,7 @@ class External(BaseParserModel):
 
 class Constraint11(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -1387,7 +1387,7 @@ class Config10(BaseParserModel):
 
 class Sources(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1421,7 +1421,7 @@ class Sources(BaseParserModel):
 
 class Argument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -1435,7 +1435,7 @@ class SupportedLanguage(Enum):
 
 class Macros(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['macro']
@@ -1456,7 +1456,7 @@ class Macros(BaseParserModel):
 
 class Docs19(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['doc']
@@ -1492,7 +1492,7 @@ class Maturity(Enum):
 
 class DependsOn11(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = None
     nodes: Optional[List[str]] = None
@@ -1500,7 +1500,7 @@ class DependsOn11(BaseParserModel):
 
 class Exposures(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['exposure']
@@ -1536,21 +1536,21 @@ class Type13(Enum):
 
 class WhereFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_sql_template: str
 
 
 class Filter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class Measure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter] = None
@@ -1561,14 +1561,14 @@ class Measure(BaseParserModel):
 
 class Filter1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class InputMeasure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter1] = None
@@ -1579,7 +1579,7 @@ class InputMeasure(BaseParserModel):
 
 class Filter2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
@@ -1594,7 +1594,7 @@ class Granularity(Enum):
 
 class OffsetWindow(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -1610,7 +1610,7 @@ class OffsetToGrain(Enum):
 
 class Numerator(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter2] = None
@@ -1621,14 +1621,14 @@ class Numerator(BaseParserModel):
 
 class Filter3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class OffsetWindow1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -1636,7 +1636,7 @@ class OffsetWindow1(BaseParserModel):
 
 class Denominator(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter3] = None
@@ -1647,7 +1647,7 @@ class Denominator(BaseParserModel):
 
 class Window(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -1663,14 +1663,14 @@ class GrainToDate(Enum):
 
 class Filter4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class OffsetWindow2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -1678,7 +1678,7 @@ class OffsetWindow2(BaseParserModel):
 
 class Metric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter4] = None
@@ -1689,14 +1689,14 @@ class Metric(BaseParserModel):
 
 class Filter5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class BaseMeasure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter5] = None
@@ -1707,14 +1707,14 @@ class BaseMeasure(BaseParserModel):
 
 class Filter6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class ConversionMeasure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter6] = None
@@ -1730,7 +1730,7 @@ class Calculation(Enum):
 
 class Window1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -1738,7 +1738,7 @@ class Window1(BaseParserModel):
 
 class ConstantProperty(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     base_property: str
     conversion_property: str
@@ -1746,7 +1746,7 @@ class ConstantProperty(BaseParserModel):
 
 class ConversionTypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     base_measure: BaseMeasure = Field(..., title='MetricInputMeasure')
     conversion_measure: ConversionMeasure = Field(..., title='MetricInputMeasure')
@@ -1758,7 +1758,7 @@ class ConversionTypeParams(BaseParserModel):
 
 class TypeParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     measure: Optional[Measure] = None
     input_measures: Optional[List[InputMeasure]] = None
@@ -1773,14 +1773,14 @@ class TypeParams(BaseParserModel):
 
 class Filter7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class FileSlice(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     filename: str
     content: str
@@ -1790,7 +1790,7 @@ class FileSlice(BaseParserModel):
 
 class Metadata1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -1807,7 +1807,7 @@ class Config12(BaseParserModel):
 
 class Metrics(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['metric']
@@ -1836,7 +1836,7 @@ class Metrics(BaseParserModel):
 
 class Groups(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['group']
@@ -1849,7 +1849,7 @@ class Groups(BaseParserModel):
 
 class Docs20(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -1895,7 +1895,7 @@ class Type14(Enum):
 
 class Constraint12(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -1920,7 +1920,7 @@ class Columns11(BaseParserModel):
 
 class Contract18(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -1929,7 +1929,7 @@ class Contract18(BaseParserModel):
 
 class Disabled(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1999,7 +1999,7 @@ class Config14(BaseParserModel):
 
 class Constraint13(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -2024,7 +2024,7 @@ class Columns12(BaseParserModel):
 
 class Disabled1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2069,7 +2069,7 @@ class Disabled1(BaseParserModel):
 
 class Contract20(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2106,7 +2106,7 @@ class Config15(BaseParserModel):
 
 class Constraint14(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -2131,7 +2131,7 @@ class Columns13(BaseParserModel):
 
 class Contract21(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2140,7 +2140,7 @@ class Contract21(BaseParserModel):
 
 class Disabled2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2186,7 +2186,7 @@ class Disabled2(BaseParserModel):
 
 class Contract22(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2224,7 +2224,7 @@ class Config16(BaseParserModel):
 
 class Constraint15(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -2249,7 +2249,7 @@ class Columns14(BaseParserModel):
 
 class Contract23(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2258,7 +2258,7 @@ class Contract23(BaseParserModel):
 
 class Constraint16(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -2270,7 +2270,7 @@ class Constraint16(BaseParserModel):
 
 class Disabled3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2321,7 +2321,7 @@ class Disabled3(BaseParserModel):
 
 class Contract24(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2358,7 +2358,7 @@ class Config17(BaseParserModel):
 
 class Constraint17(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -2383,7 +2383,7 @@ class Columns15(BaseParserModel):
 
 class Contract25(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2392,7 +2392,7 @@ class Contract25(BaseParserModel):
 
 class Disabled4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2437,7 +2437,7 @@ class Disabled4(BaseParserModel):
 
 class Contract26(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2474,7 +2474,7 @@ class Config18(BaseParserModel):
 
 class Constraint18(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -2499,7 +2499,7 @@ class Columns16(BaseParserModel):
 
 class Contract27(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2508,7 +2508,7 @@ class Contract27(BaseParserModel):
 
 class Disabled5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2578,7 +2578,7 @@ class Config19(BaseParserModel):
 
 class Constraint19(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -2603,7 +2603,7 @@ class Columns17(BaseParserModel):
 
 class Disabled6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     test_metadata: TestMetadata = Field(..., title='TestMetadata')
     database: Optional[str] = None
@@ -2652,7 +2652,7 @@ class Disabled6(BaseParserModel):
 
 class Contract29(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2694,7 +2694,7 @@ class Config20(BaseParserModel):
 
 class Constraint20(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -2719,7 +2719,7 @@ class Columns18(BaseParserModel):
 
 class Contract30(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2728,7 +2728,7 @@ class Contract30(BaseParserModel):
 
 class Disabled7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2774,7 +2774,7 @@ class Disabled7(BaseParserModel):
 
 class Contract31(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2812,7 +2812,7 @@ class Config21(BaseParserModel):
 
 class Constraint21(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -2837,7 +2837,7 @@ class Columns19(BaseParserModel):
 
 class Contract32(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2846,7 +2846,7 @@ class Contract32(BaseParserModel):
 
 class Disabled8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -2894,7 +2894,7 @@ class Disabled8(BaseParserModel):
 
 class Contract33(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     alias_types: Optional[bool] = True
@@ -2933,7 +2933,7 @@ class Config22(BaseParserModel):
 
 class Constraint22(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -2958,14 +2958,14 @@ class Columns20(BaseParserModel):
 
 class DependsOn22(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = None
 
 
 class Disabled9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -3001,7 +3001,7 @@ class Disabled9(BaseParserModel):
 
 class WarnAfter1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -3009,7 +3009,7 @@ class WarnAfter1(BaseParserModel):
 
 class ErrorAfter1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -3017,7 +3017,7 @@ class ErrorAfter1(BaseParserModel):
 
 class Freshness1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[WarnAfter1] = None
     error_after: Optional[ErrorAfter1] = None
@@ -3038,7 +3038,7 @@ class External1(BaseParserModel):
 
 class Constraint23(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type14
     name: Optional[str] = None
@@ -3071,7 +3071,7 @@ class Config23(BaseParserModel):
 
 class Disabled10(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -3113,7 +3113,7 @@ class Type26(Enum):
 
 class DependsOn23(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = None
     nodes: Optional[List[str]] = None
@@ -3121,7 +3121,7 @@ class DependsOn23(BaseParserModel):
 
 class Disabled11(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['exposure']
@@ -3157,14 +3157,14 @@ class Type27(Enum):
 
 class Filter8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class Measure1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter8] = None
@@ -3175,14 +3175,14 @@ class Measure1(BaseParserModel):
 
 class Filter9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class InputMeasure1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter9] = None
@@ -3193,14 +3193,14 @@ class InputMeasure1(BaseParserModel):
 
 class Filter10(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class OffsetWindow3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -3208,7 +3208,7 @@ class OffsetWindow3(BaseParserModel):
 
 class Numerator1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter10] = None
@@ -3219,14 +3219,14 @@ class Numerator1(BaseParserModel):
 
 class Filter11(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class OffsetWindow4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -3234,7 +3234,7 @@ class OffsetWindow4(BaseParserModel):
 
 class Denominator1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter11] = None
@@ -3245,7 +3245,7 @@ class Denominator1(BaseParserModel):
 
 class Window2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -3253,14 +3253,14 @@ class Window2(BaseParserModel):
 
 class Filter12(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class OffsetWindow5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -3268,7 +3268,7 @@ class OffsetWindow5(BaseParserModel):
 
 class Metric1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter12] = None
@@ -3279,14 +3279,14 @@ class Metric1(BaseParserModel):
 
 class Filter13(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class BaseMeasure1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter13] = None
@@ -3297,14 +3297,14 @@ class BaseMeasure1(BaseParserModel):
 
 class Filter14(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class ConversionMeasure1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     filter: Optional[Filter14] = None
@@ -3315,7 +3315,7 @@ class ConversionMeasure1(BaseParserModel):
 
 class Window3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     granularity: Granularity
@@ -3323,7 +3323,7 @@ class Window3(BaseParserModel):
 
 class ConversionTypeParams1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     base_measure: BaseMeasure1 = Field(..., title='MetricInputMeasure')
     conversion_measure: ConversionMeasure1 = Field(..., title='MetricInputMeasure')
@@ -3335,7 +3335,7 @@ class ConversionTypeParams1(BaseParserModel):
 
 class TypeParams1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     measure: Optional[Measure1] = None
     input_measures: Optional[List[InputMeasure1]] = None
@@ -3350,14 +3350,14 @@ class TypeParams1(BaseParserModel):
 
 class Filter15(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class Metadata2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3374,7 +3374,7 @@ class Config25(BaseParserModel):
 
 class Disabled12(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: Literal['metric']
@@ -3424,14 +3424,14 @@ class ResourceType(Enum):
 
 class Where(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class QueryParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metrics: List[str]
     group_by: List[str]
@@ -3445,7 +3445,7 @@ class ExportAs(Enum):
 
 class Config26(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     export_as: ExportAs
     schema_name: Optional[str] = None
@@ -3454,7 +3454,7 @@ class Config26(BaseParserModel):
 
 class Export(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     config: Config26 = Field(..., title='ExportConfig')
@@ -3462,7 +3462,7 @@ class Export(BaseParserModel):
 
 class Metadata3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3482,7 +3482,7 @@ class Config27(BaseParserModel):
 
 class Disabled13(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType
@@ -3507,7 +3507,7 @@ class Disabled13(BaseParserModel):
 
 class NodeRelation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     alias: str
     schema_name: str
@@ -3517,7 +3517,7 @@ class NodeRelation(BaseParserModel):
 
 class Defaults(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     agg_time_dimension: Optional[str] = None
 
@@ -3531,7 +3531,7 @@ class Type28(Enum):
 
 class Entity(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Type28
@@ -3555,7 +3555,7 @@ class Agg(Enum):
 
 class AggParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     percentile: Optional[float] = None
     use_discrete_percentile: Optional[bool] = False
@@ -3576,7 +3576,7 @@ class WindowChoice(Enum):
 
 class NonAdditiveDimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     window_choice: WindowChoice
@@ -3585,7 +3585,7 @@ class NonAdditiveDimension(BaseParserModel):
 
 class Measure2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     agg: Agg
@@ -3613,7 +3613,7 @@ class TimeGranularity(Enum):
 
 class ValidityParams(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     is_start: Optional[bool] = False
     is_end: Optional[bool] = False
@@ -3621,7 +3621,7 @@ class ValidityParams(BaseParserModel):
 
 class TypeParams2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     time_granularity: TimeGranularity
     validity_params: Optional[ValidityParams] = None
@@ -3629,7 +3629,7 @@ class TypeParams2(BaseParserModel):
 
 class Metadata4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3637,7 +3637,7 @@ class Metadata4(BaseParserModel):
 
 class Dimension(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Type29
@@ -3651,7 +3651,7 @@ class Dimension(BaseParserModel):
 
 class Metadata5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3669,7 +3669,7 @@ class Config28(BaseParserModel):
 
 class Disabled14(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType
@@ -3703,7 +3703,7 @@ class Format(Enum):
 
 class GivenItem(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     input: str
     rows: Optional[Union[str, List[Dict[str, Any]]]] = None
@@ -3713,7 +3713,7 @@ class GivenItem(BaseParserModel):
 
 class Expect(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     rows: Optional[Union[str, List[Dict[str, Any]]]] = None
     format: Optional[Format] = 'dict'
@@ -3731,7 +3731,7 @@ class Config29(BaseParserModel):
 
 class Disabled15(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     model: str
     given: List[GivenItem]
@@ -3754,14 +3754,14 @@ class Disabled15(BaseParserModel):
 
 class Where1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     where_filters: List[WhereFilter]
 
 
 class QueryParams1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metrics: List[str]
     group_by: List[str]
@@ -3770,7 +3770,7 @@ class QueryParams1(BaseParserModel):
 
 class Config30(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     export_as: ExportAs
     schema_name: Optional[str] = None
@@ -3779,7 +3779,7 @@ class Config30(BaseParserModel):
 
 class Export1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     config: Config30 = Field(..., title='ExportConfig')
@@ -3787,7 +3787,7 @@ class Export1(BaseParserModel):
 
 class Metadata6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3807,7 +3807,7 @@ class Config31(BaseParserModel):
 
 class SavedQueries(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType
@@ -3839,7 +3839,7 @@ class Type30(Enum):
 
 class Entity1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Type30
@@ -3851,7 +3851,7 @@ class Entity1(BaseParserModel):
 
 class NonAdditiveDimension1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     window_choice: WindowChoice
@@ -3860,7 +3860,7 @@ class NonAdditiveDimension1(BaseParserModel):
 
 class Measure3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     agg: Agg
@@ -3880,7 +3880,7 @@ class Type31(Enum):
 
 class TypeParams3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     time_granularity: TimeGranularity
     validity_params: Optional[ValidityParams] = None
@@ -3888,7 +3888,7 @@ class TypeParams3(BaseParserModel):
 
 class Metadata7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3896,7 +3896,7 @@ class Metadata7(BaseParserModel):
 
 class Dimension1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Type31
@@ -3910,7 +3910,7 @@ class Dimension1(BaseParserModel):
 
 class Metadata8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     repo_file_path: str
     file_slice: FileSlice = Field(..., title='FileSlice')
@@ -3928,7 +3928,7 @@ class Config32(BaseParserModel):
 
 class SemanticModels(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType
@@ -3957,7 +3957,7 @@ class SemanticModels(BaseParserModel):
 
 class GivenItem1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     input: str
     rows: Optional[Union[str, List[Dict[str, Any]]]] = None
@@ -3967,7 +3967,7 @@ class GivenItem1(BaseParserModel):
 
 class Expect1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     rows: Optional[Union[str, List[Dict[str, Any]]]] = None
     format: Optional[Format] = 'dict'
@@ -3985,7 +3985,7 @@ class Config33(BaseParserModel):
 
 class UnitTests(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     model: str
     given: List[GivenItem1]
@@ -4008,7 +4008,7 @@ class UnitTests(BaseParserModel):
 
 class ManifestV12(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: Metadata = Field(
         ..., description='Metadata about the manifest', title='ManifestMetadata'

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v2.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v2.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -142,7 +142,7 @@ class ResourceType5(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -187,7 +187,7 @@ class ResourceType9(Enum):
 
 class ParsedDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -266,7 +266,7 @@ class ResourceType13(Enum):
 
 class ParsedSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -335,7 +335,7 @@ class ResourceType14(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -425,7 +425,7 @@ class ResourceType16(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -435,7 +435,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v1.json'
     dbt_version: Optional[str] = '0.20.0rc1'
@@ -450,7 +450,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -472,7 +472,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     period: Period
@@ -501,14 +501,14 @@ class ResourceType17(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -517,7 +517,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -558,7 +558,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     email: str
     name: Optional[str] = None
@@ -585,7 +585,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -653,7 +653,7 @@ class CompiledDataTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -714,7 +714,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -776,7 +776,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -837,7 +837,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -907,7 +907,7 @@ class CompiledSchemaTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -969,7 +969,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1030,7 +1030,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1086,7 +1086,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1143,7 +1143,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1199,7 +1199,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1255,7 +1255,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1293,7 +1293,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -1302,7 +1302,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1326,7 +1326,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -1352,7 +1352,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     unique_id: str
@@ -1379,7 +1379,7 @@ class ParsedExposure(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1440,7 +1440,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1480,7 +1480,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v3.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v3.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -136,7 +136,7 @@ class ResourceType5(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -182,7 +182,7 @@ class ResourceType9(Enum):
 
 class ParsedDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -256,7 +256,7 @@ class ResourceType13(Enum):
 
 class ParsedSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -320,7 +320,7 @@ class ResourceType14(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -413,7 +413,7 @@ class ResourceType16(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -423,7 +423,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v2.json'
     dbt_version: Optional[str] = '0.21.0rc1'
@@ -438,7 +438,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -460,7 +460,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     period: Period
@@ -468,7 +468,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -498,14 +498,14 @@ class ResourceType17(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -514,7 +514,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -555,7 +555,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     email: str
     name: Optional[str] = None
@@ -583,7 +583,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledDataTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -646,7 +646,7 @@ class CompiledDataTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -709,7 +709,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -773,7 +773,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -836,7 +836,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSchemaTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -901,7 +901,7 @@ class CompiledSchemaTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -965,7 +965,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1028,7 +1028,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1086,7 +1086,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1145,7 +1145,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1203,7 +1203,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1261,7 +1261,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1300,7 +1300,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -1309,7 +1309,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1336,7 +1336,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -1362,7 +1362,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     unique_id: str
@@ -1389,7 +1389,7 @@ class ParsedExposure(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1452,7 +1452,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1492,7 +1492,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v4.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v4.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -140,7 +140,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -186,7 +186,7 @@ class ResourceType10(Enum):
 
 class ParsedSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -264,7 +264,7 @@ class ResourceType15(Enum):
 
 class ParsedGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -329,7 +329,7 @@ class ResourceType16(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -422,7 +422,7 @@ class ResourceType18(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -432,7 +432,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.0.0rc2'
@@ -447,7 +447,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -469,7 +469,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -477,7 +477,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -507,14 +507,14 @@ class ResourceType19(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -523,7 +523,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -566,7 +566,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     email: str
     name: Optional[str] = None
@@ -574,7 +574,7 @@ class ExposureOwner(BaseParserModel):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     field: str
     operator: str
@@ -603,7 +603,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -666,7 +666,7 @@ class CompiledSingularTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -729,7 +729,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -793,7 +793,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -856,7 +856,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -919,7 +919,7 @@ class CompiledSqlNode(BaseParserModel):
 
 class CompiledGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -985,7 +985,7 @@ class CompiledGenericTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1049,7 +1049,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1112,7 +1112,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1170,7 +1170,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1229,7 +1229,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1287,7 +1287,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1345,7 +1345,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1403,7 +1403,7 @@ class ParsedSqlNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1442,7 +1442,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1451,7 +1451,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1478,7 +1478,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -1504,7 +1504,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     unique_id: str
@@ -1531,7 +1531,7 @@ class ParsedExposure(BaseParserModel):
 
 class ParsedMetric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     unique_id: str
@@ -1562,7 +1562,7 @@ class ParsedMetric(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1625,7 +1625,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1665,7 +1665,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v5.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v5.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -140,7 +140,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -187,7 +187,7 @@ class ResourceType10(Enum):
 
 class ParsedSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -265,7 +265,7 @@ class ResourceType15(Enum):
 
 class ParsedGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -330,7 +330,7 @@ class ResourceType16(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -424,7 +424,7 @@ class ResourceType18(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -434,7 +434,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.1.0b1'
@@ -449,7 +449,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -471,7 +471,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -479,7 +479,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -509,14 +509,14 @@ class ResourceType19(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -525,7 +525,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -568,7 +568,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     email: str
     name: Optional[str] = None
@@ -576,7 +576,7 @@ class ExposureOwner(BaseParserModel):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     field: str
     operator: str
@@ -606,7 +606,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -669,7 +669,7 @@ class CompiledSingularTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -733,7 +733,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -798,7 +798,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -862,7 +862,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -926,7 +926,7 @@ class CompiledSqlNode(BaseParserModel):
 
 class CompiledGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -992,7 +992,7 @@ class CompiledGenericTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1057,7 +1057,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1121,7 +1121,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1180,7 +1180,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1240,7 +1240,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1299,7 +1299,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1358,7 +1358,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1417,7 +1417,7 @@ class ParsedSqlNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1456,7 +1456,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1465,7 +1465,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1492,7 +1492,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -1518,7 +1518,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     unique_id: str
@@ -1545,7 +1545,7 @@ class ParsedExposure(BaseParserModel):
 
 class ParsedMetric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     unique_id: str
@@ -1576,7 +1576,7 @@ class ParsedMetric(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1640,7 +1640,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1680,7 +1680,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v6.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v6.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -79,14 +79,14 @@ class ColumnInfo(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
 
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -140,7 +140,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -188,7 +188,7 @@ class ResourceType10(Enum):
 
 class ParsedSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -267,7 +267,7 @@ class ResourceType15(Enum):
 
 class ParsedGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -333,7 +333,7 @@ class ResourceType16(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -430,7 +430,7 @@ class ResourceType18(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -440,7 +440,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.2.0'
@@ -455,7 +455,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -477,7 +477,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -485,7 +485,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -515,14 +515,14 @@ class ResourceType19(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -531,7 +531,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -574,7 +574,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     email: str
     name: Optional[str] = None
@@ -582,7 +582,7 @@ class ExposureOwner(BaseParserModel):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     field: str
     operator: str
@@ -613,7 +613,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -677,7 +677,7 @@ class CompiledSingularTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -743,7 +743,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -810,7 +810,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -876,7 +876,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -942,7 +942,7 @@ class CompiledSqlNode(BaseParserModel):
 
 class CompiledGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     test_metadata: TestMetadata
@@ -1009,7 +1009,7 @@ class CompiledGenericTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1076,7 +1076,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1142,7 +1142,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1203,7 +1203,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1265,7 +1265,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1326,7 +1326,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1387,7 +1387,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1448,7 +1448,7 @@ class ParsedSqlNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     database: Optional[str] = None
@@ -1488,7 +1488,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1497,7 +1497,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1524,7 +1524,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -1550,7 +1550,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     unique_id: str
@@ -1577,7 +1577,7 @@ class ParsedExposure(BaseParserModel):
 
 class ParsedMetric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     unique_id: str
@@ -1610,7 +1610,7 @@ class ParsedMetric(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     raw_sql: str
     compiled: bool
@@ -1676,7 +1676,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1716,7 +1716,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v7.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v7.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -67,7 +67,7 @@ class Docs(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -87,7 +87,7 @@ class ColumnInfo(BaseParserModel):
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -141,7 +141,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -194,7 +194,7 @@ class ResourceType10(Enum):
 
 class ParsedSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -274,7 +274,7 @@ class ResourceType15(Enum):
 
 class ParsedGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     test_metadata: TestMetadata
     database: Optional[str] = None
@@ -341,7 +341,7 @@ class ResourceType16(Enum):
 
 class ParsedSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -447,7 +447,7 @@ class ResourceType18(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -457,7 +457,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.3.0b2'
@@ -472,7 +472,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -494,7 +494,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -502,7 +502,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -537,14 +537,14 @@ class SupportedLanguage(Enum):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
 
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -553,7 +553,7 @@ class MacroArgument(BaseParserModel):
 
 class ParsedDocumentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -596,7 +596,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     email: str
     name: Optional[str] = None
@@ -611,7 +611,7 @@ class ExposureConfig(BaseParserModel):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     field: str
     operator: str
@@ -627,7 +627,7 @@ class Period1(Enum):
 
 class MetricTime(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period1] = None
@@ -669,7 +669,7 @@ class NodeConfig(BaseParserModel):
 
 class CompiledSingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     compiled: bool
     database: Optional[str] = None
@@ -734,7 +734,7 @@ class CompiledSingularTestNode(BaseParserModel):
 
 class CompiledModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     compiled: bool
     database: Optional[str] = None
@@ -804,7 +804,7 @@ class CompiledModelNode(BaseParserModel):
 
 class CompiledHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     compiled: bool
     database: Optional[str] = None
@@ -875,7 +875,7 @@ class CompiledHookNode(BaseParserModel):
 
 class CompiledRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     compiled: bool
     database: Optional[str] = None
@@ -945,7 +945,7 @@ class CompiledRPCNode(BaseParserModel):
 
 class CompiledSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     compiled: bool
     database: Optional[str] = None
@@ -1015,7 +1015,7 @@ class CompiledSqlNode(BaseParserModel):
 
 class CompiledGenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     test_metadata: TestMetadata
     compiled: bool
@@ -1083,7 +1083,7 @@ class CompiledGenericTestNode(BaseParserModel):
 
 class CompiledSeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     compiled: bool
     database: Optional[str] = None
@@ -1154,7 +1154,7 @@ class CompiledSeedNode(BaseParserModel):
 
 class CompiledSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     compiled: bool
     database: Optional[str] = None
@@ -1224,7 +1224,7 @@ class CompiledSnapshotNode(BaseParserModel):
 
 class ParsedAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1289,7 +1289,7 @@ class ParsedAnalysisNode(BaseParserModel):
 
 class ParsedHookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1355,7 +1355,7 @@ class ParsedHookNode(BaseParserModel):
 
 class ParsedModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1420,7 +1420,7 @@ class ParsedModelNode(BaseParserModel):
 
 class ParsedRPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1485,7 +1485,7 @@ class ParsedRPCNode(BaseParserModel):
 
 class ParsedSqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1550,7 +1550,7 @@ class ParsedSqlNode(BaseParserModel):
 
 class ParsedSnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1591,7 +1591,7 @@ class ParsedSnapshotNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1600,7 +1600,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1627,7 +1627,7 @@ class ExternalTable(BaseParserModel):
 
 class ParsedMacro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     package_name: str
@@ -1654,7 +1654,7 @@ class ParsedMacro(BaseParserModel):
 
 class ParsedExposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     unique_id: str
@@ -1686,7 +1686,7 @@ class ParsedExposure(BaseParserModel):
 
 class ParsedMetric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     unique_id: str
@@ -1724,7 +1724,7 @@ class ParsedMetric(BaseParserModel):
 
 class CompiledAnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     compiled: bool
     database: Optional[str] = None
@@ -1794,7 +1794,7 @@ class CompiledAnalysisNode(BaseParserModel):
 
 class ParsedSourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     fqn: List[str]
     database: Optional[str] = None
@@ -1834,7 +1834,7 @@ class ParsedSourceDefinition(BaseParserModel):
 
 class ManifestV7(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v8.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v8.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -79,7 +79,7 @@ class ColumnInfo(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -87,7 +87,7 @@ class DependsOn(BaseParserModel):
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -141,7 +141,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -218,7 +218,7 @@ class SeedConfig(BaseParserModel):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
 
@@ -229,7 +229,7 @@ class ResourceType9(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -239,7 +239,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.4.1'
@@ -254,7 +254,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -276,7 +276,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -284,7 +284,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -319,7 +319,7 @@ class SupportedLanguage(Enum):
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -332,7 +332,7 @@ class ResourceType11(Enum):
 
 class Documentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType11
@@ -363,7 +363,7 @@ class Maturity(Enum):
 
 class ExposureOwner(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     email: str
     name: Optional[str] = None
@@ -382,7 +382,7 @@ class ResourceType13(Enum):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     field: str
     operator: str
@@ -398,7 +398,7 @@ class Period1(Enum):
 
 class MetricTime(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period1] = None
@@ -440,7 +440,7 @@ class NodeConfig(BaseParserModel):
 
 class SingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -504,7 +504,7 @@ class SingularTestNode(BaseParserModel):
 
 class HookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -574,7 +574,7 @@ class HookNode(BaseParserModel):
 
 class ModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -643,7 +643,7 @@ class ModelNode(BaseParserModel):
 
 class RPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -712,7 +712,7 @@ class RPCNode(BaseParserModel):
 
 class SqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -781,7 +781,7 @@ class SqlNode(BaseParserModel):
 
 class GenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     test_metadata: TestMetadata
     database: Optional[str] = None
@@ -848,7 +848,7 @@ class GenericTestNode(BaseParserModel):
 
 class SnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -893,7 +893,7 @@ class SnapshotNode(BaseParserModel):
 
 class SeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -955,7 +955,7 @@ class SeedNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -964,7 +964,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -991,7 +991,7 @@ class ExternalTable(BaseParserModel):
 
 class Macro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType10
@@ -1016,7 +1016,7 @@ class Macro(BaseParserModel):
 
 class Exposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType12
@@ -1048,7 +1048,7 @@ class Exposure(BaseParserModel):
 
 class Metric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType13
@@ -1085,7 +1085,7 @@ class Metric(BaseParserModel):
 
 class AnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1154,7 +1154,7 @@ class AnalysisNode(BaseParserModel):
 
 class SourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1193,7 +1193,7 @@ class SourceDefinition(BaseParserModel):
 
 class ManifestV8(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v9.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v9.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class ManifestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[
         str
@@ -42,7 +42,7 @@ class ResourceType(Enum):
 
 class FileHash(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     checksum: str
@@ -50,7 +50,7 @@ class FileHash(BaseParserModel):
 
 class Hook(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     sql: str
     transaction: Optional[bool] = True
@@ -59,7 +59,7 @@ class Hook(BaseParserModel):
 
 class Docs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     show: Optional[bool] = True
     node_color: Optional[str] = None
@@ -67,7 +67,7 @@ class Docs(BaseParserModel):
 
 class ContractConfig(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
 
@@ -83,7 +83,7 @@ class Type(Enum):
 
 class ColumnLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -94,7 +94,7 @@ class ColumnLevelConstraint(BaseParserModel):
 
 class RefArgs(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     package: Optional[str] = None
@@ -103,7 +103,7 @@ class RefArgs(BaseParserModel):
 
 class DependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
     nodes: Optional[List[str]] = []
@@ -111,7 +111,7 @@ class DependsOn(BaseParserModel):
 
 class InjectedCTE(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     id: str
     sql: str
@@ -119,7 +119,7 @@ class InjectedCTE(BaseParserModel):
 
 class Contract(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     enforced: Optional[bool] = False
     checksum: Optional[str] = None
@@ -168,7 +168,7 @@ class Access(Enum):
 
 class ModelLevelConstraint(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     type: Type
     name: Optional[str] = None
@@ -192,7 +192,7 @@ class ResourceType6(Enum):
 
 class TestMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     kwargs: Optional[Dict[str, Any]] = {}
@@ -277,7 +277,7 @@ class SeedConfig(BaseParserModel):
 
 class MacroDependsOn(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     macros: Optional[List[str]] = []
 
@@ -288,7 +288,7 @@ class ResourceType9(Enum):
 
 class Quoting(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[bool] = None
     schema_: Optional[bool] = Field(None, alias='schema')
@@ -298,7 +298,7 @@ class Quoting(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.5.0b5'
@@ -313,7 +313,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -335,7 +335,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -343,7 +343,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -378,7 +378,7 @@ class SupportedLanguage(Enum):
 
 class MacroArgument(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     type: Optional[str] = None
@@ -391,7 +391,7 @@ class ResourceType11(Enum):
 
 class Documentation(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType11
@@ -441,7 +441,7 @@ class ResourceType13(Enum):
 
 class MetricFilter(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     field: str
     operator: str
@@ -457,7 +457,7 @@ class Period1(Enum):
 
 class MetricTime(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period1] = None
@@ -477,7 +477,7 @@ class ResourceType14(Enum):
 
 class Group(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType14
@@ -534,7 +534,7 @@ class ColumnInfo(BaseParserModel):
 
 class SingularTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -605,7 +605,7 @@ class SingularTestNode(BaseParserModel):
 
 class HookNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -683,7 +683,7 @@ class HookNode(BaseParserModel):
 
 class ModelNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -764,7 +764,7 @@ class ModelNode(BaseParserModel):
 
 class RPCNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -841,7 +841,7 @@ class RPCNode(BaseParserModel):
 
 class SqlNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -918,7 +918,7 @@ class SqlNode(BaseParserModel):
 
 class GenericTestNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     test_metadata: TestMetadata
     database: Optional[str] = None
@@ -993,7 +993,7 @@ class GenericTestNode(BaseParserModel):
 
 class SnapshotNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1044,7 +1044,7 @@ class SnapshotNode(BaseParserModel):
 
 class SeedNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1109,7 +1109,7 @@ class SeedNode(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -1118,7 +1118,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -1145,7 +1145,7 @@ class ExternalTable(BaseParserModel):
 
 class Macro(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType10
@@ -1170,7 +1170,7 @@ class Macro(BaseParserModel):
 
 class Exposure(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType12
@@ -1202,7 +1202,7 @@ class Exposure(BaseParserModel):
 
 class Metric(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     resource_type: ResourceType13
@@ -1242,7 +1242,7 @@ class Metric(BaseParserModel):
 
 class AnalysisNode(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1319,7 +1319,7 @@ class AnalysisNode(BaseParserModel):
 
 class SourceDefinition(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
@@ -1358,7 +1358,7 @@ class SourceDefinition(BaseParserModel):
 
 class ManifestV9(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: ManifestMetadata = Field(..., description='Metadata about the manifest')
     nodes: Dict[

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v1.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v1.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class BaseArtifactMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '0.19.0'
@@ -44,7 +44,7 @@ class Status2(Enum):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -53,7 +53,7 @@ class TimingInfo(BaseParserModel):
 
 class RunResultOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingInfo]
@@ -66,7 +66,7 @@ class RunResultOutput(BaseParserModel):
 
 class RunResultsV1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: BaseArtifactMetadata
     results: List[RunResultOutput]

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v2.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v2.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class BaseArtifactMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '0.20.0rc1'
@@ -44,7 +44,7 @@ class Status2(Enum):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -53,7 +53,7 @@ class TimingInfo(BaseParserModel):
 
 class RunResultOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingInfo]
@@ -67,7 +67,7 @@ class RunResultOutput(BaseParserModel):
 
 class RunResultsV2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: BaseArtifactMetadata
     results: List[RunResultOutput]

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v3.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v3.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class BaseArtifactMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '0.21.0rc1'
@@ -45,7 +45,7 @@ class Status2(Enum):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -54,7 +54,7 @@ class TimingInfo(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v2.json'
     dbt_version: Optional[str] = '0.21.0rc1'
@@ -69,7 +69,7 @@ class Status3(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -91,7 +91,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     period: Period
@@ -99,7 +99,7 @@ class Time(BaseParserModel):
 
 class RunResultOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingInfo]
@@ -113,7 +113,7 @@ class RunResultOutput(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -122,7 +122,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class RunResultsV3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: BaseArtifactMetadata
     results: List[RunResultOutput]
@@ -132,7 +132,7 @@ class RunResultsV3(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v4.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v4.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class BaseArtifactMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '1.0.0b2'
@@ -45,7 +45,7 @@ class Status2(Enum):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -54,7 +54,7 @@ class TimingInfo(BaseParserModel):
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.0.0b2'
@@ -69,7 +69,7 @@ class Status3(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -91,7 +91,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -99,7 +99,7 @@ class Time(BaseParserModel):
 
 class RunResultOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingInfo]
@@ -113,7 +113,7 @@ class RunResultOutput(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -122,7 +122,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class RunResultsV4(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: BaseArtifactMetadata
     results: List[RunResultOutput]
@@ -132,7 +132,7 @@ class RunResultsV4(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v5.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v5.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class BaseArtifactMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '1.7.0b1'
@@ -24,7 +24,7 @@ class BaseArtifactMetadata(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[str] = None
@@ -54,7 +54,7 @@ class Status2(Enum):
 
 class RunResultOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingInfo]
@@ -71,7 +71,7 @@ class RunResultOutput(BaseParserModel):
 
 class RunResultsV5(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: BaseArtifactMetadata
     results: List[RunResultOutput]

--- a/dbt_artifacts_parser/parsers/run_results/run_results_v6.py
+++ b/dbt_artifacts_parser/parsers/run_results/run_results_v6.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class Metadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: str
     dbt_version: Optional[str] = '1.8.0a1'
@@ -45,7 +45,7 @@ class Status2(Enum):
 
 class TimingItem(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[str] = None
@@ -54,7 +54,7 @@ class TimingItem(BaseParserModel):
 
 class Result(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     status: Union[Status, Status1, Status2]
     timing: List[TimingItem]
@@ -71,7 +71,7 @@ class Result(BaseParserModel):
 
 class RunResultsV6(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: Metadata = Field(..., title='BaseArtifactMetadata')
     results: List[Result]

--- a/dbt_artifacts_parser/parsers/sources/sources_v1.py
+++ b/dbt_artifacts_parser/parsers/sources/sources_v1.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v1.json'
     dbt_version: Optional[str] = '0.19.0'
@@ -28,7 +28,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -50,7 +50,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     period: Period
@@ -58,7 +58,7 @@ class Time(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -67,7 +67,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -80,7 +80,7 @@ class SourceFreshnessOutput(BaseParserModel):
 
 class SourcesV1(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: FreshnessMetadata
     results: List[Union[SourceFreshnessRuntimeError, SourceFreshnessOutput]]

--- a/dbt_artifacts_parser/parsers/sources/sources_v2.py
+++ b/dbt_artifacts_parser/parsers/sources/sources_v2.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v2.json'
     dbt_version: Optional[str] = '0.21.0rc1'
@@ -28,7 +28,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -50,7 +50,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: int
     period: Period
@@ -58,7 +58,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -67,7 +67,7 @@ class TimingInfo(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
@@ -76,7 +76,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -92,7 +92,7 @@ class SourceFreshnessOutput(BaseParserModel):
 
 class SourcesV2(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: FreshnessMetadata
     results: List[Union[SourceFreshnessRuntimeError, SourceFreshnessOutput]]

--- a/dbt_artifacts_parser/parsers/sources/sources_v3.py
+++ b/dbt_artifacts_parser/parsers/sources/sources_v3.py
@@ -13,7 +13,7 @@ from dbt_artifacts_parser.parsers.base import BaseParserModel
 
 class FreshnessMetadata(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     dbt_schema_version: Optional[str] = 'https://schemas.getdbt.com/dbt/sources/v3.json'
     dbt_version: Optional[str] = '1.0.0b2'
@@ -28,7 +28,7 @@ class Status(Enum):
 
 class SourceFreshnessRuntimeError(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     error: Optional[Union[str, int]] = None
@@ -50,7 +50,7 @@ class Period(Enum):
 
 class Time(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     count: Optional[int] = None
     period: Optional[Period] = None
@@ -58,7 +58,7 @@ class Time(BaseParserModel):
 
 class TimingInfo(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     name: str
     started_at: Optional[AwareDatetime] = None
@@ -67,7 +67,7 @@ class TimingInfo(BaseParserModel):
 
 class FreshnessThreshold(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     warn_after: Optional[Time] = {'count': None, 'period': None}
     error_after: Optional[Time] = {'count': None, 'period': None}
@@ -76,7 +76,7 @@ class FreshnessThreshold(BaseParserModel):
 
 class SourceFreshnessOutput(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     unique_id: str
     max_loaded_at: AwareDatetime
@@ -92,7 +92,7 @@ class SourceFreshnessOutput(BaseParserModel):
 
 class SourcesV3(BaseParserModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra='ignore',
     )
     metadata: FreshnessMetadata
     results: List[Union[SourceFreshnessRuntimeError, SourceFreshnessOutput]]


### PR DESCRIPTION
Sets extra fields to be ignored by default and allows for null values in macro dependencies. The latest version of the manifest parser already correctly types semantic models. 