### PR TITLE
Allow dbt snapshot unique_key fields to be lists of strings

### DIFF
--- a/dbt_artifacts_parser/parsers/manifest/manifest_v1.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v1.py
@@ -391,7 +391,7 @@ class TimestampSnapshotConfig(BaseParserModel):
     database: Optional[str] = None
     tags: Optional[Union[List[str], str]] = []
     full_refresh: Optional[bool] = None
-    unique_key: str
+    unique_key: Optional[Union[str, List[str]]] = None
     target_schema: str
     target_database: Optional[str] = None
     strategy: Strategy
@@ -423,7 +423,7 @@ class CheckSnapshotConfig(BaseParserModel):
     database: Optional[str] = None
     tags: Optional[Union[List[str], str]] = []
     full_refresh: Optional[bool] = None
-    unique_key: str
+    unique_key: Optional[Union[str, List[str]]] = None
     target_schema: str
     target_database: Optional[str] = None
     strategy: Strategy1
@@ -451,7 +451,7 @@ class GenericSnapshotConfig(BaseParserModel):
     database: Optional[str] = None
     tags: Optional[Union[List[str], str]] = []
     full_refresh: Optional[bool] = None
-    unique_key: str
+    unique_key: Optional[Union[str, List[str]]] = None
     target_schema: str
     target_database: Optional[str] = None
     strategy: Strategy2

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v10.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v10.py
@@ -240,7 +240,7 @@ class SnapshotConfig(BaseParserModel):
     quoting: Optional[Dict[str, Any]] = {}
     column_types: Optional[Dict[str, Any]] = {}
     full_refresh: Optional[bool] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     on_schema_change: Optional[str] = 'ignore'
     on_configuration_change: Optional[OnConfigurationChange] = 'apply'
     grants: Optional[Dict[str, Any]] = {}

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v11.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v11.py
@@ -611,7 +611,7 @@ class SnapshotConfig(BaseParserModel):
     quoting: Optional[Dict[str, Any]] = None
     column_types: Optional[Dict[str, Any]] = None
     full_refresh: Optional[bool] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     on_schema_change: Optional[str] = 'ignore'
     on_configuration_change: Optional[OnConfigurationChange] = None
     grants: Optional[Dict[str, Any]] = None

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
@@ -2678,7 +2678,7 @@ class Config20(BaseParserModel):
     quoting: Optional[Dict[str, Any]] = None
     column_types: Optional[Dict[str, Any]] = None
     full_refresh: Optional[bool] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     on_schema_change: Optional[str] = 'ignore'
     on_configuration_change: Optional[OnConfigurationChange] = None
     grants: Optional[Dict[str, Any]] = None

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v12.py
@@ -958,7 +958,7 @@ class Config7(BaseParserModel):
     quoting: Optional[Dict[str, Any]] = None
     column_types: Optional[Dict[str, Any]] = None
     full_refresh: Optional[bool] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     on_schema_change: Optional[str] = 'ignore'
     on_configuration_change: Optional[OnConfigurationChange] = None
     grants: Optional[Dict[str, Any]] = None

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v2.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v2.py
@@ -412,7 +412,7 @@ class SnapshotConfig(BaseParserModel):
     tags: Optional[Union[List[str], str]] = []
     full_refresh: Optional[bool] = None
     strategy: Optional[str] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     target_schema: Optional[str] = None
     target_database: Optional[str] = None
     updated_at: Optional[str] = None

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v3.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v3.py
@@ -400,7 +400,7 @@ class SnapshotConfig(BaseParserModel):
     full_refresh: Optional[bool] = None
     on_schema_change: Optional[str] = 'ignore'
     strategy: Optional[str] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     target_schema: Optional[str] = None
     target_database: Optional[str] = None
     updated_at: Optional[str] = None

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v4.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v4.py
@@ -409,7 +409,7 @@ class SnapshotConfig(BaseParserModel):
     full_refresh: Optional[bool] = None
     on_schema_change: Optional[str] = 'ignore'
     strategy: Optional[str] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     target_schema: Optional[str] = None
     target_database: Optional[str] = None
     updated_at: Optional[str] = None

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v5.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v5.py
@@ -409,7 +409,7 @@ class SnapshotConfig(BaseParserModel):
     quoting: Optional[Dict[str, Any]] = {}
     column_types: Optional[Dict[str, Any]] = {}
     full_refresh: Optional[bool] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     on_schema_change: Optional[str] = 'ignore'
     strategy: Optional[str] = None
     target_schema: Optional[str] = None

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v6.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v6.py
@@ -414,7 +414,7 @@ class SnapshotConfig(BaseParserModel):
     quoting: Optional[Dict[str, Any]] = {}
     column_types: Optional[Dict[str, Any]] = {}
     full_refresh: Optional[bool] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     on_schema_change: Optional[str] = 'ignore'
     grants: Optional[Dict[str, Any]] = {}
     strategy: Optional[str] = None

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v7.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v7.py
@@ -427,7 +427,7 @@ class SnapshotConfig(BaseParserModel):
     quoting: Optional[Dict[str, Any]] = {}
     column_types: Optional[Dict[str, Any]] = {}
     full_refresh: Optional[bool] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     on_schema_change: Optional[str] = 'ignore'
     grants: Optional[Dict[str, Any]] = {}
     packages: Optional[List[str]] = []

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v8.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v8.py
@@ -170,7 +170,7 @@ class SnapshotConfig(BaseParserModel):
     quoting: Optional[Dict[str, Any]] = {}
     column_types: Optional[Dict[str, Any]] = {}
     full_refresh: Optional[bool] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     on_schema_change: Optional[str] = 'ignore'
     grants: Optional[Dict[str, Any]] = {}
     packages: Optional[List[str]] = []

--- a/dbt_artifacts_parser/parsers/manifest/manifest_v9.py
+++ b/dbt_artifacts_parser/parsers/manifest/manifest_v9.py
@@ -222,7 +222,7 @@ class SnapshotConfig(BaseParserModel):
     quoting: Optional[Dict[str, Any]] = {}
     column_types: Optional[Dict[str, Any]] = {}
     full_refresh: Optional[bool] = None
-    unique_key: Optional[str] = None
+    unique_key: Optional[Union[str, List[str]]] = None
     on_schema_change: Optional[str] = 'ignore'
     grants: Optional[Dict[str, Any]] = {}
     packages: Optional[List[str]] = []


### PR DESCRIPTION
This is why Propelus's builds are failing. We don't care about this field so doesn't matter if this isn't strictly accurate across all the manifest versions.

I tested this against one of the snapshots in their manifest, it fails to parse before this and succeeds after.